### PR TITLE
Increase auto name length to 255

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -896,6 +896,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b1611c6c50b2406a96b220768be9d6852ceb827203ac53b043fb2a344d101089"
+  inputs-digest = "a575f3b2325b7df2a4ec0840c18224611179ad8e9a158c30356c745b8e053048"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
OpenStack supports names of 255 in (as far as I can tell) all places.

Also update to make use of AutoName members from tfbridge library.